### PR TITLE
Migrate to use Fluentd v1 API

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,15 +23,20 @@ You need to install ZeroMQ libraries before installing this plugin
 == Configuration
 
   <match zmq.**>
-    type zmq_pub
+    @type zmq_pub
     pubkey ${tag}:${key1}
     bindaddr tcp://*:5556
     flush_interval 1s
     bulk_send true
+    <buffer tag, key1>
+      @type memory
+    </buffer>
   </match>
 
-* 'pubkey' specifies the publish key to ZeroMQ. 
-  * '${tag}' is replace by fluentd tag. '${name}' is replaced by fluentd record['name']. 
+* 'pubkey' specifies the publish key to ZeroMQ.
+  * '${tag}' is replace by fluentd tag. '${name}' is replaced by fluentd record['name'].
+    * Fluentd built-in placehodlers requests to use custom '<buffer>' attributes.
+    * In more detail, please refer to the official document: https://docs.fluentd.org/v1.0/articles/buffer-section#placeholders
   * Actual record to be published is '<pubkey> <reocord.to_msgpack>'.
   * Subscriber can subscribe by '<pubkey>'.
 * 'bindaddr' is the address to which ZeroMQ publisher socket to be bound.
@@ -57,14 +62,16 @@ Put the configuration above to fluentd.conf, and save this sample code as 'sampl
   else
     subscriber.setsockopt(ZMQ::SUBSCRIBE,"")
   end
-  
+
   while true
     msg = ''
     while subscriber.recv_string(msg,ZMQ::DONTWAIT) && msg.size > 0
-      record =  MessagePack.unpack(msg.split(" ",2)[1])
-      puts "tag: #{record[0]}"
-      puts "time: #{record[1]}"
-      puts "record: #{record[2]}"
+      records =  MessagePack.unpack(msg.split(" ",2)[1])
+      records.each do |record|
+        puts "tag: #{record[0]}"
+        puts "time: #{record[1]}"
+        puts "record: #{record[2]}"
+      end
       msg = ''
     end
     sleep(0.1)
@@ -94,7 +101,7 @@ The nice thing is that once you put this plugin to your fluentd.conf and start f
 Input plugin to subscribe the output of zmq_pub is also included. Here is the example configuration.
 
     <source>
-       type zmq_sub
+       @type zmq_sub
        publisher tcp://127.0.0.1:5556
        bulk_send true
        subkey zmq.,zmq2

--- a/fluent-plugin-zmq-pub.gemspec
+++ b/fluent-plugin-zmq-pub.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = "0.0.5"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit", "~> 3.2.0"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_runtime_dependency "ffi-rzmq"
 end

--- a/lib/fluent/plugin/in_zmq_sub.rb
+++ b/lib/fluent/plugin/in_zmq_sub.rb
@@ -1,11 +1,13 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 
-module Fluent
+module Fluent::Plugin
 
-  class ZmqSubInput < Fluent::Input
+  class ZmqSubInput < Input
     Fluent::Plugin.register_input('zmq_sub', self)
 
-    config_param :subkey, :string, :default => ""
+    helpers :thread
+
+    config_param :subkey, :array, :default => []
     config_param :publisher, :string, :default => "tcp://127.0.0.1:5556"
     config_param :bulk_send, :bool, :default => false
 
@@ -18,69 +20,64 @@ module Fluent
 
     def configure(conf)
       super
-      @subkeys = @subkey.split(",")
+      @subkeys = @subkey # for compatibility.
+      @unpacker = Fluent::Engine.msgpack_factory.unpacker
     end
 
     def start
       super
       @context =ZMQ::Context.new()
-      @thread = Thread.new(&method(:run))
+      thread_create(:in_zmq_sub_runner, &method(:run))
     end
 
     def shutdown
-      Thread.kill(@thread)
-      @thread.join
+      if @subscriber
+        @subscriber.close
+      end
+
       @context.terminate
       super
     end
 
     def run
-      begin
-        @subscriber = @context.socket(ZMQ::SUB)
-        @subscriber.connect(@publisher)
-        if @subkeys.size > 0
-          @subkeys.each do |k|
-            @subscriber.setsockopt(ZMQ::SUBSCRIBE,k)
-          end
-        else
-          @subscriber.setsockopt(ZMQ::SUBSCRIBE,'')
+      @subscriber = @context.socket(ZMQ::SUB)
+      @subscriber.connect(@publisher)
+      if @subkeys.size > 0
+        @subkeys.each do |k|
+          @subscriber.setsockopt(ZMQ::SUBSCRIBE,k)
         end
-        loop do
-          msg = ''
-          while @subscriber.recv_string(msg,ZMQ::DONTWAIT) && msg.size > 0
-            begin
-              (key, records) = msg.split(" ",2)
-              records = MessagePack.unpack(records)
-              if @bulk_send && records[0].class == Array
-                es = MultiEventStream.new
+      else
+        @subscriber.setsockopt(ZMQ::SUBSCRIBE,'')
+      end
+      loop do
+        msg = ''
+        while @subscriber.recv_string(msg,ZMQ::DONTWAIT) && msg.size > 0
+          begin
+            (key, records) = msg.split(" ",2)
+            @unpacker.feed_each(records) do |obj|
+              if @bulk_send && obj[0].class == Array
+                es = Fluent::MultiEventStream.new
                 prev_tag = nil
-                records.each do |tag, time, record|
+                obj.each do |tag, time, record|
                   if prev_tag && prev_tag != tag
-                    Engine.emit_stream(prev_tag, es)
-                    es = MultiEventStream.new
+                    router.emit_stream(prev_tag, es)
+                    es = Fluent::MultiEventStream.new
                   end
                   es.add(time, record)
                   prev_tag = tag
                 end
-                Engine.emit_stream(prev_tag, es) if es.to_a.size > 0
+                router.emit_stream(prev_tag, es) if es.to_a.size > 0
               else
-                Engine.emit(*records)
+                router.emit(*obj)
               end
-            rescue => e
-              log.warn "Error in processing message.",:error_class => e.class, :error => e
-              log.warn_backtrace
             end
-            msg = ''
+          rescue => e
+            log.warn "Error in processing message.",:error_class => e.class, :error => e
+            log.warn_backtrace
           end
-          sleep(0.1)
+          msg = ''
         end
-      rescue => e
-        log.error "error occurred while executing plugin.", :error_class => e.class, :error => e
-        log.warn_backtrace
-      ensure
-        if @subscriber
-          @subscriber.close
-        end
+        sleep(0.1)
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,15 +12,6 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end
 
 require 'fluent/plugin/out_zmq_pub'
 require 'fluent/plugin/in_zmq_sub'

--- a/test/plugin/test_in_zmq_sub.rb
+++ b/test/plugin/test_in_zmq_sub.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'ffi-rzmq'
+require 'fluent/test/driver/input'
 
 class ZmqSubIutputTest < Test::Unit::TestCase
   def setup
@@ -8,7 +9,7 @@ class ZmqSubIutputTest < Test::Unit::TestCase
     @publisher = @context.socket(ZMQ::PUB)
     @publisher.bind("tcp://*:5556")
   end
-  
+
   def teardown
     @publisher.close
     @context.terminate
@@ -19,72 +20,67 @@ class ZmqSubIutputTest < Test::Unit::TestCase
      publisher #{PUBLISHER}
      subkey test1.,test2.
   ]
-  
-  
+
+
   def create_driver(conf=CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::ZmqSubInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::ZmqSubInput).configure(conf)
   end
-  
+
   def test_configure
     d = create_driver(CONFIG + "bulk_send true")
     assert_equal PUBLISHER, d.instance.publisher
     assert_equal ["test1.","test2."], d.instance.subkeys
     assert_equal true, d.instance.bulk_send
   end
-  
+
   def test_receive
     d = create_driver
-    
+
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
-    
-    d.expect_emit "test1.aa", time, {"a"=>1}
-    d.expect_emit "test2.bb", time, {"a"=>2}
-    
-    d.run do
-      d.expected_emits.each {|tag,time,record|
+
+    expected_emits = [["test1.aa", time, {"a"=>1}],["test2.bb", time, {"a"=>2}]]
+
+    d.run(expect_emits: 1, timeout: 3) do
+      expected_emits.each {|tag,time,record|
         send_record("dummy",time,record)  # This record should not be received.
         send_record(tag,time,record)
       }
-      sleep 1
     end
+
+    assert_equal expected_emits, d.events
   end
 
   def test_no_subkey
     d = create_driver("")
-    
+
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
-    
-    d.expect_emit "test1.aa", time, {"a"=>1}
-    d.expect_emit "test2.bb", time, {"a"=>2}
-    
-    d.run do
-      d.expected_emits.each {|tag,time,record|
+
+    expected_emits = [["test1.aa", time, {"a"=>1}],["test2.bb", time, {"a"=>2}]]
+    d.run(expect_emits: 1, timeout: 3) do
+      expected_emits.each {|tag,time,record|
         send_record(tag,time,record)
       }
-      sleep 1
     end
+
+    assert_equal expected_emits, d.events
   end
 
 
   def test_receive_bulk
     d = create_driver(CONFIG + "bulk_send true")
-    
+
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
-    
-    d.expect_emit "test3.aa", time, {"a"=>1}
-    d.expect_emit "test4.bb", time, {"a"=>2}
-    
-    d.run do
-      record_to_send = []
-      d.expected_emits.each {|tag,time,record|
-        record_to_send << [tag,time,record]
-      }
+
+    record_to_send = [["test3.aa", time, {"a"=>1}],["test4.bb", time, {"a"=>2}]]
+
+    d.run(expect_emits: 1, timeout: 3) do
       send_record_bulk("test1.aa",record_to_send)
-      sleep 1
     end
+
+    assert_equal record_to_send, d.events
   end
 
   def send_record(tag,time,record)

--- a/test/plugin/test_out_zeromq_pub.rb
+++ b/test/plugin/test_out_zeromq_pub.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'ffi-rzmq'
+require 'fluent/test/driver/output'
 
 class ZmqPubOutputTest < Test::Unit::TestCase
   def setup
@@ -13,7 +14,7 @@ class ZmqPubOutputTest < Test::Unit::TestCase
     @subscriber.close
     @context.terminate
   end
-  
+
   CONFIG = %[
       pubkey ${tag}:${key1}
       bindaddr tcp://*:5556
@@ -29,45 +30,89 @@ class ZmqPubOutputTest < Test::Unit::TestCase
       pubkey ${tag}
       bindaddr tcp://*:5556
   ]
-  
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::ZmqPubOutput, tag).configure(conf)
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ZmqPubOutput).configure(conf)
   end
-  
+
   def test_configure
     d = create_driver
 
     assert_equal '${tag}:${key1}', d.instance.pubkey
     assert_equal 'tcp://*:5556', d.instance.bindaddr
   end
-  
+
   def test_format
     d = create_driver
-    
+
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    d.emit({"key1"=>"aaa"}, time)
-    d.emit({"key1"=>"bbb", "key2"=>3}, time)
-    
-    d.expect_format ["test",time.to_i,{ "key1" => "aaa"}].to_msgpack
-    d.expect_format ["test",time.to_i,{ "key1" => "bbb", "key2" => 3}].to_msgpack
-    
-    d.run
+    d.run(default_tag: 'test') do
+      d.feed(time, {"key1"=>"aaa"})
+      d.feed(time, {"key1"=>"bbb", "key2"=>3})
+    end
+
+    assert_equal ["test",time.to_i,{ "key1" => "aaa"}].to_msgpack, d.formatted[0]
+    assert_equal ["test",time.to_i,{ "key1" => "bbb", "key2" => 3}].to_msgpack, d.formatted[1]
   end
-  
+
   def test_write
-    d = create_driver
+    config = Fluent::Config::Element.new('ROOT', '', {
+                                           '@type' => 'zmq_pub',
+                                           'pubkey' => '${tag}:${key1}',
+                                           'bindaddr' => 'tcp://*:5556'
+                                         }, [
+                                           Fluent::Config::Element.new('buffer', 'tag,key1', {
+                                                                         '@type' => 'memory',
+                                                                       },[] )
+                                         ])
+    d = create_driver(config)
     @subscriber.setsockopt(ZMQ::SUBSCRIBE,"test:aaa")
-    
+
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    d.emit({"key1"=>"aaa"}, time)
-    d.emit({"key1"=>"bbb", "key2"=>3}, time)
-    d.emit({"key1"=>"aaa", "key2"=>4}, time)
-    
-    d.run
+    msg = ''
+    d.run(default_tag: 'test', shutdown: false) do
+      d.feed(time, {"key1"=>"aaa"})
+      d.feed(time, {"key1"=>"bbb", "key2"=>3})
+      d.feed(time, {"key1"=>"aaa", "key2"=>4})
+    end
+
     sleep 1
+    @subscriber.recv_string(msg,ZMQ::DONTWAIT)
+    (key, record) = msg.split(" ",2)
+    assert_equal ["test",time.to_i,{ "key1" => "aaa"}].to_msgpack, record
 
     msg = ''
     @subscriber.recv_string(msg,ZMQ::DONTWAIT)
+    d.instance.shutdown # dispose
+    (key, record) = msg.split(" ",2)
+    assert_equal ["test",time.to_i,{ "key1" => "aaa","key2" => 4 }].to_msgpack, record
+
+  end
+
+  def test_write_bulk
+    config_bulk = Fluent::Config::Element.new('ROOT', '', {
+                                                '@type' => 'zmq_pub',
+                                                'pubkey' => '${tag}:${key1}',
+                                                'bindaddr' => 'tcp://*:5556'
+                                              }, [
+                                                Fluent::Config::Element.new('buffer', 'tag,key1', {
+                                                                              '@type' => 'memory',
+                                                                            },[] )
+                                              ])
+    d = create_driver(config_bulk)
+    @subscriber.setsockopt(ZMQ::SUBSCRIBE,"test:aaa")
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    msg = ''
+    d.run(default_tag: 'test', shutdown: false) do
+      d.feed(time, {"key1"=>"aaa"})
+      d.feed(time, {"key1"=>"bbb", "key2"=>3})
+      d.feed(time, {"key1"=>"aaa", "key2"=>4})
+    end
+
+    sleep 1
+    @subscriber.recv_string(msg,ZMQ::DONTWAIT)
+    d.instance.shutdown # dispose
     (key, record) = msg.split(" ",2)
     assert_equal ["test",time.to_i,{ "key1" => "aaa"}].to_msgpack, record
 
@@ -78,27 +123,5 @@ class ZmqPubOutputTest < Test::Unit::TestCase
 
   end
 
-  def test_write_bulk
-    d = create_driver(CONFIG_BULK)
-    @subscriber.setsockopt(ZMQ::SUBSCRIBE,"test:aaa")
-    
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    d.emit({"key1"=>"aaa"}, time)
-    d.emit({"key1"=>"bbb", "key2"=>3}, time)
-    d.emit({"key1"=>"aaa", "key2"=>4}, time)
-    
-    d.run
-    sleep 1
-
-    msg = ''
-    @subscriber.recv_string(msg,ZMQ::DONTWAIT)
-    (key, record) = msg.split(" ",2)
-    assert_equal [["test",time.to_i,{ "key1" => "aaa"}],
-                  ["test",time.to_i,{ "key1" => "aaa","key2" => 4 }]].to_msgpack, record
-
-  end
-
 
 end
-
-


### PR DESCRIPTION
Hi, I've migrated to use Fluentd v1 API.
The brand new v1 API can be working with multi workers, and provides elastic testing APIs.
Could you take a look?

Note that this patch contains breaking changes.
If this PR is acceptable, please bump up mior verion to follow semantic versioning.